### PR TITLE
Fix sha256 in v0.73-3

### DIFF
--- a/Formula/csshx.rb
+++ b/Formula/csshx.rb
@@ -2,7 +2,7 @@ class Csshx < Formula
   desc "Cluster ssh tool for Terminal.app"
   homepage "https://github.com/parera10/csshx"
   url "https://github.com/parera10/csshx/archive/0.73-3.tar.gz"
-  sha256 "f17986100f7c469bde8bfe2073f02c7ffcf9dac1becb623e9e39d922d1f0874a"
+  sha256 "c12e7fa99be840987809faf873b96ad5bbc24802e1d9df82391242d30744b73a"
   head "https://github.com/parera10/csshx.git"
 
   bottle :unneeded


### PR DESCRIPTION
The sha256 of v0.73-3 was wrong, so I fixed it. Please confirm this PR.

```
$ brew install parera10/csshx/csshx
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 2 formulae.

==> Installing csshx from parera10/csshx
==> Downloading https://github.com/parera10/csshx/archive/0.73-3.tar.gz
==> Downloading from https://codeload.github.com/parera10/csshx/tar.gz/0.73-3
 # #=O#-  #                                                                   
Error: SHA256 mismatch
Expected: f17986100f7c469bde8bfe2073f02c7ffcf9dac1becb623e9e39d922d1f0874a
  Actual: c12e7fa99be840987809faf873b96ad5bbc24802e1d9df82391242d30744b73a
    File: /Users/username/Library/Caches/Homebrew/downloads/d2ddb503d885b0a350c7827fbb0e26955d17296f8a630f91745f1aecb78eccf7--csshx-0.73-3.tar.gz
To retry an incomplete download, remove the file above.
```